### PR TITLE
Autostart and relay invert

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ So far this has proved to be relatively stable.
 
 ### Installation
 1. `git clone https://github.com/Jerrkawz/GarageQTPi.git`
-2. `bash install.sh`
+2. `pip install -r requirements.txt`
 3. edit the configuration.yaml to set up mqtt (See below)
 4. `python main.py` 
 5. To start the server on boot run `sudo bash autostart_systemd.sh`
@@ -144,7 +144,7 @@ doors:
 ```
 
 The state_mode parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'
-The invert_relay parameter defaults to false and isn't necessary unless you want to change it to true
+The invert_relay parameter defaults to false and isn't necessary unless you want to set the relay pin to be powered by default
         
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ doors:
 ```
 
 ### Optional configuration
-So far there is one optional configuration parameter to flip the state pin of the magnetic switch in the invent of a different wiring schema. This is a per door configuration option like:
+So far there are two optional configuration parameters. One to flip the state pin of the magnetic switch in the invent of a different wiring schema. The second one to filp the relay logic. This is a per door configuration option like:
 ```
 doors:
     -
@@ -138,11 +138,13 @@ doors:
         relay: 23
         state: 17
         state_mode: normally_closed
+        invert_relay: true
         state_topic: "home-assistant/cover/left"
         command_topic: "home-assistant/cover/left/set"
 ```
 
-This configuration parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'
+The state_mode parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'
+The invert_relay parameter defaults to false and isn't necessary unless you want to change it to true
         
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,10 @@ So far this has proved to be relatively stable.
 
 ### Installation
 1. `git clone https://github.com/Jerrkawz/GarageQTPi.git`
-2. `pip install -r requirements.txt`
+2. `bash install.sh`
 3. edit the configuration.yaml to set up mqtt (See below)
 4. `python main.py` 
-5. To start the server on boot, copy this into /etc/rc.local: `(sleep 30; cd /home/pi/GarageQTPi; python main.py)&`
-
-Note: The sleep 30 is my hack to wait until the pi has an ip address so the mqtt connection doesn't fail.
-I would like to write this as a daemon eventually and use a real startup service but until then. (or if someone wants to send a PR :) )
+5. To start the server on boot run `sudo bash autostart_systemd.sh`
 
 ## MQTT setup
 I won't try to butcher an mqtt setup guide but will instead link you to some other resources:

--- a/autostart_systemd.sh
+++ b/autostart_systemd.sh
@@ -2,4 +2,4 @@
 cp garageqtpi@pi.service /etc/systemd/system/garageqtpi@`whoami`.service
 sed -i "s?/home/pi/GarageQTPi?`pwd`?" /etc/systemd/system/garageqtpi@`whoami`.service
 systemctl --system daemon-reload
-systemctl enable home-assistant@`whoami`
+systemctl enable home-assistant@`whoami`.service

--- a/autostart_systemd.sh
+++ b/autostart_systemd.sh
@@ -2,4 +2,4 @@
 cp garageqtpi@pi.service /etc/systemd/system/garageqtpi@`whoami`.service
 sed -i "s?/home/pi/GarageQTPi?`pwd`?" /etc/systemd/system/garageqtpi@`whoami`.service
 systemctl --system daemon-reload
-systemctl enable home-assistant@`whoami`.service
+systemctl enable garageqtpi@`whoami`.service

--- a/autostart_systemd.sh
+++ b/autostart_systemd.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cp garageqtpi@pi.service /etc/systemd/system/garageqtpi@`whoami`.service
+sed -i "s?/home/pi/GarageQTPi?`pwd`?" /etc/systemd/system/garageqtpi@`whoami`.service
+systemctl --system daemon-reload
+systemctl enable home-assistant@`whoami`

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ doors:
         relay:
         state:
 #        state_mode: normally_closed #defaults to normally open, uncomment to switch
+#        invert_relay: true #defaults to false, uncomment to turn relay pin on by default
         state_topic: "home-assistant/cover"
         command_topic: "home-assistant/cover/set"
 

--- a/garageqtpi@pi.service
+++ b/garageqtpi@pi.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=GarageQTPi
+After=network.target
+
+[Service]
+Type=simple
+User=%i
+ExecStart=/usr/bin/python /home/pi/GarageQTPi/main.py
+
+[Install]
+WantedBy=multi-user.target

--- a/garageqtpi@pi.service
+++ b/garageqtpi@pi.service
@@ -4,6 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
+Restart=always
+RestartSec=3
 User=%i
 ExecStart=/usr/bin/python /home/pi/GarageQTPi/main.py
 

--- a/lib/garage.py
+++ b/lib/garage.py
@@ -19,20 +19,22 @@ class GarageDoor(object):
         self.state_pin = config['state']
         self.id = config['id']
         self.mode = int(config.get('state_mode') == 'normally_closed')
+        self.invert_relay = bool(config.get('invert_relay'))
 
         # Setup
         self._state = None
         self.onStateChange = EventHook()
 
         # Set relay pin to output, state pin to input, and add a change listener to the state pin
+        GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self.relay_pin, GPIO.OUT)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
 
 
-        # Set default relay state to true (off)
-        GPIO.output(self.relay_pin, True)
+        # Set default relay state to false (off)
+        GPIO.output(self.relay_pin, self.invert_relay)
 
     # Release rpi resources
     def __del__(self):
@@ -64,9 +66,9 @@ class GarageDoor(object):
 
     # Mimick a button press by switching the GPIO pin on and off quickly
     def __press(self):
-        GPIO.output(self.relay_pin, False)
+        GPIO.output(self.relay_pin, not self.invert_relay)
         time.sleep(SHORT_WAIT)
-        GPIO.output(self.relay_pin, True)
+        GPIO.output(self.relay_pin, self.invert_relay)
 
    
     # Provide an event for when the state pin changes

--- a/lib/garage.py
+++ b/lib/garage.py
@@ -79,4 +79,3 @@ class GarageDoor(object):
             time.sleep(SHORT_WAIT)
             self.onStateChange.fire(self.state)
 
-    

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def execute_command(door, command):
     else:
         print "Invalid command: %s" % command
 
-with open("config.yaml", 'r') as ymlfile:
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'config.yaml'), 'r') as ymlfile:
     CONFIG = yaml.load(ymlfile)
 
 ### SETUP MQTT ###


### PR DESCRIPTION
I added support for inverting the relay logic (new default is relay pin off by default), and created an autostart script for systemd.
I also changed the config file from using the working directory to using the same directory as the main.py file.