### PR TITLE
Added support for HomeAssistant MQTT discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,9 @@ HomeAssistant MQTT Setup: https://home-assistant.io/components/mqtt/
 Bruh Automation: https://www.youtube.com/watch?v=AsDHEDbyLfg
 
 ## Home Assistant component setup
-Either follow the cover setup or enable mqtt discovery
-
-HomeAssistant MQTT Cover: https://home-assistant.io/components/cover.mqtt/
+Either follow the cover setup or enable mqtt discovery  
+HomeAssistant MQTT Cover: https://home-assistant.io/components/cover.mqtt/  
 HomeAssistant MQTT Discovery: https://home-assistant.io/docs/mqtt/discovery/
-
 
 Screenshot:
 
@@ -138,7 +136,7 @@ doors:
 ```
 
 ### Optional configuration
-There are five optional configuration parameters.
+There are five optional configuration parameters.  
 Two of the option parameters are for mqtt.  One is to enable discovery by HomeAssistant. The second one changes the discovery prefix for HomeAssitant.
 ```
 mqtt:
@@ -150,12 +148,10 @@ mqtt:
     discovery_prefix: 'homeassistant'
 ```
 
-The discovery parameter defaults to false and should be set to true to enable discovery by HomeAssistant. If set to true, the door state_topic and command_topic parameters are not necessary and are ignored.
+The discovery parameter defaults to false and should be set to true to enable discovery by HomeAssistant. If set to true, the door state_topic and command_topic parameters are not necessary and are ignored.  
 The discovery_prefix parameter defaults to 'homeassistant' and shouldn't be changed unless changed in HomeAssistant
 
 The other three of the option parameters are for the doors. One to give the door a name for discovery.  The second one to flip the state pin of the magnetic switch in the invent of a different wiring schema. The third one to filp the relay logic.  This is a per door configuration option like:
-
-
 ```
 doors:
     -
@@ -169,8 +165,8 @@ doors:
         command_topic: "home-assistant/cover/left/set"
 ```
 
-The name parameter defaults to the unsanitized id parameter
-The state_mode parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'
+The name parameter defaults to the unsanitized id parameter  
+The state_mode parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'  
 The invert_relay parameter defaults to false and isn't necessary unless you want to set the relay pin to be powered by default
         
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ HomeAssistant MQTT Setup: https://home-assistant.io/components/mqtt/
 Bruh Automation: https://www.youtube.com/watch?v=AsDHEDbyLfg
 
 ## Home Assistant component setup
+Either follow the cover setup or enable mqtt discovery
+
 HomeAssistant MQTT Cover: https://home-assistant.io/components/cover.mqtt/
+HomeAssistant MQTT Discovery: https://home-assistant.io/docs/mqtt/discovery/
+
 
 Screenshot:
 
@@ -134,11 +138,29 @@ doors:
 ```
 
 ### Optional configuration
-So far there are two optional configuration parameters. One to flip the state pin of the magnetic switch in the invent of a different wiring schema. The second one to filp the relay logic. This is a per door configuration option like:
+There are five optional configuration parameters.
+Two of the option parameters are for mqtt.  One is to enable discovery by HomeAssistant. The second one changes the discovery prefix for HomeAssitant.
+```
+mqtt:
+    host: m10.cloudmqtt.com
+    port: *
+    user: *
+    password: *
+    discovery: true
+    discovery_prefix: 'homeassistant'
+```
+
+The discovery parameter defaults to false and should be set to true to enable discovery by HomeAssistant. If set to true, the door state_topic and command_topic parameters are not necessary and are ignored.
+The discovery_prefix parameter defaults to 'homeassistant' and shouldn't be changed unless changed in HomeAssistant
+
+The other three of the option parameters are for the doors. One to give the door a name for discovery.  The second one to flip the state pin of the magnetic switch in the invent of a different wiring schema. The third one to filp the relay logic.  This is a per door configuration option like:
+
+
 ```
 doors:
     -
         id: 'left'
+        name: 'Left Garage Door'
         relay: 23
         state: 17
         state_mode: normally_closed
@@ -147,6 +169,7 @@ doors:
         command_topic: "home-assistant/cover/left/set"
 ```
 
+The name parameter defaults to the unsanitized id parameter
 The state_mode parameter defaults to 'normally_open' and isn't necessary unless you want to change it to 'normally_closed'
 The invert_relay parameter defaults to false and isn't necessary unless you want to set the relay pin to be powered by default
         

--- a/config.yaml
+++ b/config.yaml
@@ -3,11 +3,14 @@ mqtt:
     port: 
     user: 
     password: 
+#    discovery: true #defaults to false, uncomment to enable home-assistant discovery
+#    discovery_prefix: homeassistant #change to match with setting of home-assistant
 doors:
     -
         id: 
-        relay:
-        state:
+#        name: #defaults to an unsanitized version of the id paramater
+        relay: 
+        state: 
 #        state_mode: normally_closed #defaults to normally open, uncomment to switch
 #        invert_relay: true #defaults to false, uncomment to turn relay pin on by default
         state_topic: "home-assistant/cover"

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import binascii
 import yaml
 import paho.mqtt.client as mqtt
+import re
 
 from lib.garage import GarageDoor
 
@@ -23,7 +24,7 @@ def on_connect(client, userdata, rc):
 
 # Execute the specified command for a door
 def execute_command(door, command):
-    print "Executing command %s for door %s" % (command, door.id)
+    print "Executing command %s for door %s" % (command, door.name)
     if command == "OPEN" and door.state == 'closed':
         door.open()
     elif command == "CLOSE" and door.state == 'open':
@@ -41,6 +42,11 @@ user = CONFIG['mqtt']['user']
 password = CONFIG['mqtt']['password']
 host = CONFIG['mqtt']['host']
 port = int(CONFIG['mqtt']['port'])
+discovery = bool(CONFIG['mqtt'].get('discovery'))
+if 'discovery_prefix' not in CONFIG['mqtt']:
+    discovery_prefix = 'homeassistant'
+else:
+    discovery_prefix = CONFIG['mqtt']['discovery_prefix']
 
 client = mqtt.Client(client_id="MQTTGarageDoor_" + binascii.b2a_hex(os.urandom(6)), clean_session=True, userdata=None, protocol=3)
 
@@ -54,8 +60,22 @@ client.connect(host, port, 60)
 if __name__ == "__main__":
     # Create door objects and create callback functions
     for doorCfg in CONFIG['doors']:
-        command_topic = doorCfg['command_topic']
-        state_topic = doorCfg['state_topic']
+
+        # If no name it set, then set to id
+        if not doorCfg['name']:
+            doorCfg['name'] = doorCfg['id']
+
+        # Sanitize id value for mqtt
+        doorCfg['id'] = re.sub('\W+', '', re.sub('\s', ' ', doorCfg['id']))
+
+        if discovery is True:
+            base_topic = discovery_prefix + "/cover/" + doorCfg['id']
+            config_topic = base_topic + "/config"
+            command_topic = doorCfg['command_topic'] = base_topic + "/set"
+            state_topic = doorCfg['state_topic'] = base_topic + "/state"
+        else:
+            command_topic = doorCfg['command_topic']
+            state_topic = doorCfg['state_topic']
 
 
         door = GarageDoor(doorCfg)
@@ -75,6 +95,10 @@ if __name__ == "__main__":
 
         # Publish initial door state
         client.publish(state_topic, door.state, retain=True)
+
+        # If discovery is enabled publish configuration
+        if discovery is True:
+            client.publish(config_topic,'{"name": "' + doorCfg['name'] + '", "command_topic": "' + command_topic + '", "state_topic": "' + state_topic + '"}', retain=True)
 
     # Main loop
     client.loop_forever()

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ if 'discovery_prefix' not in CONFIG['mqtt']:
 else:
     discovery_prefix = CONFIG['mqtt']['discovery_prefix']
 
-client = mqtt.Client(client_id="MQTTGarageDoor_" + binascii.b2a_hex(os.urandom(6)), clean_session=True, userdata=None, protocol=3)
+client = mqtt.Client(client_id="MQTTGarageDoor_" + binascii.b2a_hex(os.urandom(6)), clean_session=True, userdata=None, protocol=4)
 
 client.on_connect = on_connect
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,11 @@ def on_connect(client, userdata, rc):
 
 # Execute the specified command for a door
 def execute_command(door, command):
-    print "Executing command %s for door %s" % (command, door.name)
+    try:
+        doorName = door.name
+    except:
+        doorName = door.id
+    print "Executing command %s for door %s" % (command, doorName)
     if command == "OPEN" and door.state == 'closed':
         door.open()
     elif command == "CLOSE" and door.state == 'open':
@@ -71,11 +75,11 @@ if __name__ == "__main__":
         if discovery is True:
             base_topic = discovery_prefix + "/cover/" + doorCfg['id']
             config_topic = base_topic + "/config"
-            command_topic = doorCfg['command_topic'] = base_topic + "/set"
-            state_topic = doorCfg['state_topic'] = base_topic + "/state"
-        else:
-            command_topic = doorCfg['command_topic']
-            state_topic = doorCfg['state_topic']
+            doorCfg['command_topic'] = base_topic + "/set"
+            doorCfg['state_topic'] = base_topic + "/state"
+        
+        command_topic = doorCfg['command_topic']
+        state_topic = doorCfg['state_topic']
 
 
         door = GarageDoor(doorCfg)


### PR DESCRIPTION
I added support for HomeAssistant MQTT discovery 
https://www.home-assistant.io/docs/mqtt/discovery/

I could change the setup to require the user to still set the command_topic and state_topic, or use what is set if it exists.

The readme may need to be modified to make it easier to understand.