### PR TITLE
fix boot trigger of relay

### DIFF
--- a/lib/garage.py
+++ b/lib/garage.py
@@ -29,12 +29,12 @@ class GarageDoor(object):
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self.relay_pin, GPIO.OUT)
+        # Set default relay state to false (off)
+        GPIO.output(self.relay_pin, self.invert_relay)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
 
 
-        # Set default relay state to false (off)
-        GPIO.output(self.relay_pin, self.invert_relay)
 
     # Release rpi resources
     def __del__(self):


### PR DESCRIPTION
I fixed the issue I was reporting ( https://github.com/Jerrkawz/GarageQTPi/issues/35 ) and wanted to share my solution.

I found that the call to GPIO.setup(self.relay_pin, GPIO.OUT) starts with the GPIO sending the signal to the relay and turns off a few lines down when GPIO.output(self.relay_pin, self.invert_relay) is called. 

So I moved GPIO.output(self.relay_pin, self.invert_relay) right after the setup and the trigger no longer happens.