### PR TITLE
Set initial relay output on pin setup.

### DIFF
--- a/lib/garage.py
+++ b/lib/garage.py
@@ -28,13 +28,10 @@ class GarageDoor(object):
         # Set relay pin to output, state pin to input, and add a change listener to the state pin
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
-        GPIO.setup(self.relay_pin, GPIO.OUT)
+        # Initial output value = high if self.invert_relay is True
+        GPIO.setup(self.relay_pin, GPIO.OUT, initial=self.invert_relay)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
-
-
-        # Set default relay state to false (off)
-        GPIO.output(self.relay_pin, self.invert_relay)
 
     # Release rpi resources
     def __del__(self):


### PR DESCRIPTION
For relays that use invert_relay as True, on output pin setup, there is a short toggle between Low and High that triggers the relay between the original GPIO.setup and the output line that sets the initial state.

The GPIO.setup() has an optional parameter initial to set the initial state on setup.