### PR TITLE
Set GPIO pin state when initialising

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,18 +1,19 @@
+
 mqtt:
-    host: 
-    port: 
-    user: 
-    password: 
+  host:
+  port:
+  user:
+  password:
 #    discovery: true #defaults to false, uncomment to enable home-assistant discovery
 #    discovery_prefix: homeassistant #change to match with setting of home-assistant
+
 doors:
-    -
-        id: 
-#        name: #defaults to an unsanitized version of the id paramater
-        relay: 
-        state: 
-#        state_mode: normally_closed #defaults to normally open, uncomment to switch
-#        invert_relay: true #defaults to false, uncomment to turn relay pin on by default
-        state_topic: "home-assistant/cover"
-        command_topic: "home-assistant/cover/set"
+  - id:
+    #        name: #defaults to an unsanitized version of the id paramater
+    relay:
+    state:
+    #        state_mode: normally_closed #defaults to normally open, uncomment to switch
+    #        invert_relay: true #defaults to false, uncomment to turn relay pin on by default
+    state_topic: "home-assistant/cover"
+    command_topic: "home-assistant/cover/set"
 

--- a/garageqtpi@pi.service
+++ b/garageqtpi@pi.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=always
 RestartSec=3
 User=%i
-ExecStart=/usr/bin/python -u /home/pi/GarageQTPi/main.py
+ExecStart=/home/pi/GarageQTPi/venv/bin/python3.9 -u /home/pi/GarageQTPi/main.py
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/garage.py
+++ b/lib/garage.py
@@ -1,17 +1,17 @@
 import time
 import RPi.GPIO as GPIO
-from eventhook import EventHook
+from lib.eventhook import EventHook
 
 
 SHORT_WAIT = .2 #S (200ms)
 """
-    The purpose of this class is to map the idea of a garage door to the pinouts on 
+    The purpose of this class is to map the idea of a garage door to the pinouts on
     the raspberrypi. It provides methods to control the garage door and also provides
     and event hook to notify you of the state change. It also doesn't maintain any
     state internally but rather relies directly on reading the pin.
 """
 class GarageDoor(object):
-    
+
     def __init__(self, config):
 
         # Config
@@ -31,6 +31,10 @@ class GarageDoor(object):
         GPIO.setup(self.relay_pin, GPIO.OUT, initial=self.invert_relay)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
+
+
+        # Set default relay state to false (off)
+        #GPIO.output(self.relay_pin, self.invert_relay)
 
     # Release rpi resources
     def __del__(self):
@@ -68,7 +72,7 @@ class GarageDoor(object):
         time.sleep(SHORT_WAIT)
         GPIO.output(self.relay_pin, self.invert_relay)
 
-   
+
     # Provide an event for when the state pin changes
     def __stateChanged(self, channel):
         if channel == self.state_pin:
@@ -76,4 +80,3 @@ class GarageDoor(object):
             # after a statechange and then grab the state
             time.sleep(SHORT_WAIT)
             self.onStateChange.fire(self.state)
-

--- a/lib/garage.py
+++ b/lib/garage.py
@@ -28,13 +28,9 @@ class GarageDoor(object):
         # Set relay pin to output, state pin to input, and add a change listener to the state pin
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
-        GPIO.setup(self.relay_pin, GPIO.OUT)
+        GPIO.setup(self.relay_pin, GPIO.OUT, initial=self.invert_relay)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
-
-
-        # Set default relay state to false (off)
-        GPIO.output(self.relay_pin, self.invert_relay)
 
     # Release rpi resources
     def __del__(self):

--- a/lib/garage.py
+++ b/lib/garage.py
@@ -2,8 +2,10 @@ import time
 import RPi.GPIO as GPIO
 from lib.eventhook import EventHook
 
+# S (200ms)
+SHORT_WAIT = .2
 
-SHORT_WAIT = .2 #S (200ms)
+
 """
     The purpose of this class is to map the idea of a garage door to the pinouts on
     the raspberrypi. It provides methods to control the garage door and also provides
@@ -30,11 +32,7 @@ class GarageDoor(object):
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self.relay_pin, GPIO.OUT, initial=self.invert_relay)
         GPIO.setup(self.state_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-        GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__stateChanged, bouncetime=300)
-
-
-        # Set default relay state to false (off)
-        #GPIO.output(self.relay_pin, self.invert_relay)
+        GPIO.add_event_detect(self.state_pin, GPIO.BOTH, callback=self.__state_changed, bouncetime=300)
 
     # Release rpi resources
     def __del__(self):
@@ -58,8 +56,8 @@ class GarageDoor(object):
     # State is a read only property that actually gets its value from the pin
     @property
     def state(self):
-        # Read the mode from the config. Then compare the mode to the current state. IE. If the circuit is normally closed and the state is 1 then the circuit is closed.
-        # and vice versa for normally open
+        # Read the mode from the config. Then compare the mode to the current state. IE. If the circuit is normally
+        # closed and the state is 1 then the circuit is closed and vice versa for normally open
         state = GPIO.input(self.state_pin)
         if  state == self.mode:
             return 'closed'
@@ -72,9 +70,8 @@ class GarageDoor(object):
         time.sleep(SHORT_WAIT)
         GPIO.output(self.relay_pin, self.invert_relay)
 
-
     # Provide an event for when the state pin changes
-    def __stateChanged(self, channel):
+    def __state_changed(self, channel):
         if channel == self.state_pin:
             # Had some issues getting an accurate value so we are going to wait for a short timeout
             # after a statechange and then grab the state

--- a/main.py
+++ b/main.py
@@ -40,7 +40,6 @@ def execute_command(door, command):
     else:
         print("Invalid command: %s" % command)
 
-
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'config.yaml'), 'r') as ymlfile:
     CONFIG = yaml.safe_load(ymlfile)
 


### PR DESCRIPTION
Hi,

I'm using the `invert_relay: true` option as my relay module needs to be pulled down to ground to turn on

Currently the GPIO output is set some time after it is initialised, this meant on restart (say a power loss etc) the relay would briefly toggle resulting in the garage door opening.

This is a small change to set the state when the initialising the GPIO pin, I also added hardware pull ups in my case

I have some other changes locally, upgrading to python3 etc, would you be interesting in accepting those later?

Cheers,
Dan